### PR TITLE
Update Fragment_profile.kt

### DIFF
--- a/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
+++ b/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
@@ -106,18 +106,19 @@ class FragmentProfile : Fragment() {
         return email.substring(0, 10).uppercase(Locale.getDefault())
     }
 
-    private fun calculateCurrentYear(rollNo: String): Int {
+   private fun calculateCurrentYear(rollNo: String): String {
         val admissionYear = rollNo.substring(3, 7).toInt()
         val calendar = Calendar.getInstance()
         val currentYear = calendar.get(Calendar.YEAR)
-        val currentMonth = calendar.get(Calendar.MONTH) 
-    
-        val academicYearStart = if (currentMonth >= Calendar.AUGUST) {
-            currentYear 
+        val currentMonth = calendar.get(Calendar.MONTH)
+
+        val acadYear = if (currentMonth >= Calendar.AUGUST) {
+            currentYear - admissionYear + 1
         } else {
-            currentYear - 1
+            currentYear - admissionYear
         }
-        return academicYearStart - admissionYear + 1
+
+        return acadYear.toString() + getSuffix(acadYear)
     }
 
     private fun getSuffix(year: Int): String {

--- a/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
+++ b/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
@@ -106,7 +106,7 @@ class FragmentProfile : Fragment() {
         return email.substring(0, 10).uppercase(Locale.getDefault())
     }
 
-    private fun calculateCurrentYear(rollNo: String): String {
+    private fun calculateCurrentYear(rollNo: String): Int {
         val admissionYear = rollNo.substring(3, 7).toInt()
         val calendar = Calendar.getInstance()
         val currentYear = calendar.get(Calendar.YEAR)

--- a/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
+++ b/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
@@ -108,9 +108,16 @@ class FragmentProfile : Fragment() {
 
     private fun calculateCurrentYear(rollNo: String): String {
         val admissionYear = rollNo.substring(3, 7).toInt()
-        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-        val acadYear = currentYear - admissionYear + 1
-        return acadYear.toString() + getSuffix(acadYear)
+        val calendar = Calendar.getInstance()
+        val currentYear = calendar.get(Calendar.YEAR)
+        val currentMonth = calendar.get(Calendar.MONTH) 
+    
+        val academicYearStart = if (currentMonth >= Calendar.AUGUST) {
+            currentYear 
+        } else {
+            currentYear - 1
+        }
+        return academicYearStart - admissionYear + 1
     }
 
     private fun getSuffix(year: Int): String {


### PR DESCRIPTION
resolves #3 
Improved the logic such that the current month is retrieved using Calendar.MONTH, if the current month is august or later, the academic year starts in the current calendar year but if the current month is before august the academic year started in the previous calendar year.

Finally return academicYearStart-admissionYear+1 to get the correct year.

![Screenshot 2025-03-29 010543](https://github.com/user-attachments/assets/2f632a8c-b3f0-4c36-b685-7c4a35c141d9)
