### PR TITLE
Update Fragment_profile.kt

### DIFF
--- a/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
+++ b/app/src/main/java/com/example/collegefixit/Fragments/Fragment_profile.kt
@@ -107,12 +107,13 @@ class FragmentProfile : Fragment() {
     }
 
     private fun calculateCurrentYear(rollNo: String): String {
-        val admissionYear = rollNo.substring(3, 7).toInt()
-        val currentYear = Calendar.getInstance().get(Calendar.YEAR)
-        val acadYear = currentYear - admissionYear + 1
-        return acadYear.toString() + getSuffix(acadYear)
-    }
+    val admissionYear = rollNo.substring(3, 7).toInt()
+    val currentYear = Calendar.getInstance().get(Calendar.YEAR)
+    val acadYear = (currentYear * 12 + 8) / 12 - admissionYear
 
+    return acadYear.toString() + getSuffix(acadYear)
+}
+    
     private fun getSuffix(year: Int): String {
         if (year in 11..13) {
             return "th"


### PR DESCRIPTION
dealt mathematically 


Instead of checking the month directly, we approximate August using:

yearx12 +8 / 12 
​ 
This shifts the year forward when we pass August.

If the current date is in August or later, the calculation ensures that the year progresses correctly.

If before August, it remains in the previous academic year.
![image](https://github.com/user-attachments/assets/762cb02e-a959-4873-a4d2-b54d51c892c1)
