### PR TITLE
fixed keyboard UI shift by setting windowSoftInputMode in Manifets

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -59,6 +59,7 @@
 <!--        </activity>-->
         <activity
             android:name=".MainActivity"
+            android:windowSoftInputMode="adjustPan"
             android:exported="true" />
 
 


### PR DESCRIPTION
resolve #2 
Added android:windowSoftInputMode="adjustPan" to the activity in AndroidManifest.xml to prevent UI shifts when the keyboard appears.

https://github.com/user-attachments/assets/522205df-c391-4525-935e-2645456eaf1a

